### PR TITLE
Use phantom types to get type safety

### DIFF
--- a/phantom-type-tests/IncorrectFieldOrder.elm
+++ b/phantom-type-tests/IncorrectFieldOrder.elm
@@ -1,0 +1,28 @@
+module IncorrectFieldOrder exposing (User, userDecoder)
+
+import Json.Decode as JD
+import Json.Decode.Safe as JDS
+
+
+userDecoder : JD.Decoder User
+userDecoder =
+    JDS.record User userConstructor
+        |> JDS.field "lastName" .lastName JD.string
+        |> JDS.field "firstName" .firstName JD.string
+        |> JDS.field "pets" .pets JD.int
+        |> JDS.endRecord
+
+
+userConstructor : a -> b -> c -> { firstName : a, lastName : b, pets : c }
+userConstructor firstName lastName pets =
+    { firstName = firstName
+    , lastName = lastName
+    , pets = pets
+    }
+
+
+type alias User =
+    { firstName : String
+    , lastName : String
+    , pets : Int
+    }

--- a/phantom-type-tests/IncorrectFieldOrder.txt
+++ b/phantom-type-tests/IncorrectFieldOrder.txt
@@ -1,0 +1,46 @@
+-- TYPE MISMATCH --------------------------------------- IncorrectFieldOrder.elm
+
+This function cannot handle the argument sent through the (|>) pipe:
+
+ 9|     JDS.record User userConstructor
+10|         |> JDS.field "lastName" .lastName JD.string
+11|         |> JDS.field "firstName" .firstName JD.string
+12|         |> JDS.field "pets" .pets JD.int
+13|         |> JDS.endRecord
+               ^^^^^^^^^^^^^
+The argument is:
+
+    JDS.SafeDecoder
+        { expectedFieldOrder :
+              { firstName : JDS.Zero
+              , lastName : JDS.OnePlus JDS.Zero
+              , pets : JDS.OnePlus (JDS.OnePlus JDS.Zero)
+              }
+        , gotFieldOrder :
+              { firstName : JDS.OnePlus JDS.Zero
+              , lastName : JDS.Zero
+              , pets : JDS.OnePlus (JDS.OnePlus JDS.Zero)
+              }
+        , recordType : User
+        , totalFieldCount : JDS.OnePlus (JDS.OnePlus (JDS.OnePlus JDS.Zero))
+        }
+        User
+
+But (|>) is piping it to a function that expects:
+
+    JDS.SafeDecoder
+        { expectedFieldOrder :
+              { firstName : JDS.Zero
+              , lastName : JDS.OnePlus JDS.Zero
+              , pets : JDS.OnePlus (JDS.OnePlus JDS.Zero)
+              }
+        , gotFieldOrder :
+              { firstName : JDS.Zero
+              , lastName : JDS.OnePlus JDS.Zero
+              , pets : JDS.OnePlus (JDS.OnePlus JDS.Zero)
+              }
+        , recordType : User
+        , totalFieldCount : JDS.OnePlus (JDS.OnePlus (JDS.OnePlus JDS.Zero))
+        }
+        User
+

--- a/phantom-type-tests/MissingFields.elm
+++ b/phantom-type-tests/MissingFields.elm
@@ -1,0 +1,27 @@
+module MissingFields exposing (User, userDecoder)
+
+import Json.Decode as JD
+import Json.Decode.Safe as JDS
+
+
+userDecoder : JD.Decoder User
+userDecoder =
+    JDS.record User userConstructor
+        |> JDS.field "firstName" .firstName JD.string
+        |> JDS.field "lastName" .lastName JD.string
+        |> JDS.endRecord
+
+
+userConstructor : a -> b -> c -> { firstName : a, lastName : b, pets : c }
+userConstructor firstName lastName pets =
+    { firstName = firstName
+    , lastName = lastName
+    , pets = pets
+    }
+
+
+type alias User =
+    { firstName : String
+    , lastName : String
+    , pets : Int
+    }

--- a/phantom-type-tests/MissingFields.txt
+++ b/phantom-type-tests/MissingFields.txt
@@ -1,0 +1,45 @@
+-- TYPE MISMATCH --------------------------------------------- MissingFields.elm
+
+This function cannot handle the argument sent through the (|>) pipe:
+
+ 9|     JDS.record User userConstructor
+10|         |> JDS.field "firstName" .firstName JD.string
+11|         |> JDS.field "lastName" .lastName JD.string
+12|         |> JDS.endRecord
+               ^^^^^^^^^^^^^
+The argument is:
+
+    JDS.SafeDecoder
+        { expectedFieldOrder :
+              c
+              -> { firstName : JDS.Zero
+                 , lastName : JDS.OnePlus JDS.Zero
+                 , pets : c
+                 }
+        , gotFieldOrder :
+              { a | firstName : JDS.Zero, lastName : JDS.OnePlus JDS.Zero }
+        , recordType : Int -> User
+        , totalFieldCount : JDS.OnePlus (JDS.OnePlus JDS.Zero)
+        }
+        (Int -> User)
+
+But (|>) is piping it to a function that expects:
+
+    JDS.SafeDecoder
+        { expectedFieldOrder :
+              c
+              -> { firstName : JDS.Zero
+                 , lastName : JDS.OnePlus JDS.Zero
+                 , pets : c
+                 }
+        , gotFieldOrder :
+              c
+              -> { firstName : JDS.Zero
+                 , lastName : JDS.OnePlus JDS.Zero
+                 , pets : c
+                 }
+        , recordType : Int -> User
+        , totalFieldCount : JDS.OnePlus (JDS.OnePlus JDS.Zero)
+        }
+        (Int -> User)
+

--- a/phantom-type-tests/elm.json
+++ b/phantom-type-tests/elm.json
@@ -1,0 +1,19 @@
+{
+    "type": "application",
+    "source-directories": [
+        ".",
+        "../src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3"
+        },
+        "indirect": {}
+    },
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
+}

--- a/phantom-type-tests/run.js
+++ b/phantom-type-tests/run.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require("child_process");
+
+const files = fs.readdirSync(__dirname);
+const elmFiles = files.filter(file => file.endsWith(".elm"));
+
+elmFiles.forEach(elmFile => {
+  const expectedOutput = fs.readFileSync(path.join(__dirname, `${elmFile.slice(0, -4)}.txt`), 'utf8');
+
+  try {
+    const output = execSync(`elm make ./${elmFile}`, {encoding:"utf8", stdio: 'pipe', cwd: __dirname}).toString();
+    console.log(`ERROR: File ${elmFile} compiled, though it shouldn't have!`);
+    process.exit(1);
+  }
+  catch (error) {
+    if (error.stderr !== expectedOutput) {
+        console.log(`ERROR: File ${elmFile} failed to compile, but with the wrong error message!`);
+        console.log(`EXPECTED:\n\n${expectedOutput}\n\n`);
+        console.log(`GOT:\n\n${error.stderr}`);
+        process.exit(1);
+    }
+  }
+});
+
+console.log('No problems with phantom types!');

--- a/src/Json/Decode/Safe.elm
+++ b/src/Json/Decode/Safe.elm
@@ -73,7 +73,7 @@ record :
         SafeDecoder
             { recordType : constructor
             , expectedFieldOrder : validator
-            , gotFieldOrder : a -> Bool
+            , gotFieldOrder : a
             , totalFieldCount : Zero
             }
             constructor
@@ -103,7 +103,7 @@ field :
         SafeDecoder
             { expectedFieldOrder : totalFieldCount -> nextValidator
             , recordType : fieldValue -> nextConstructor
-            , gotFieldOrder : expectedFieldOrder -> Bool
+            , gotFieldOrder : expectedFieldOrder
             , totalFieldCount : totalFieldCount
             }
             (fieldValue -> nextConstructor)
@@ -111,7 +111,7 @@ field :
         SafeDecoder
             { expectedFieldOrder : nextValidator
             , recordType : nextConstructor
-            , gotFieldOrder : expectedFieldOrder -> Bool
+            , gotFieldOrder : expectedFieldOrder
             , totalFieldCount : OnePlus totalFieldCount
             }
             nextConstructor
@@ -142,7 +142,7 @@ endRecord :
     SafeDecoder
         { safety
             | expectedFieldOrder : expectedFieldOrder
-            , gotFieldOrder : expectedFieldOrder -> Bool
+            , gotFieldOrder : expectedFieldOrder
         }
         recordType
     -> JD.Decoder recordType

--- a/src/Json/Decode/Safe.elm
+++ b/src/Json/Decode/Safe.elm
@@ -1,18 +1,26 @@
-module Json.Decode.Safe exposing (record, field, endRecord)
+module Json.Decode.Safe exposing
+    ( record, field, endRecord
+    , Zero, OnePlus
+    )
 
 {-|
 
 @docs record, field, endRecord
+@docs Zero, OnePlus
 
 -}
 
 import Json.Decode as JD
 
 
+{-| Used for type safety.
+-}
 type Zero
     = Zero
 
 
+{-| Used for type safety.
+-}
 type OnePlus a
     = OnePlus a
 

--- a/src/Json/Decode/Safe.elm
+++ b/src/Json/Decode/Safe.elm
@@ -23,13 +23,13 @@ type SafeDecoder safety a
 {-| Used for type safety.
 -}
 type Zero
-    = Zero
+    = Zero Never
 
 
 {-| Used for type safety.
 -}
 type OnePlus a
-    = OnePlus a
+    = OnePlus Never
 
 
 {-| Start constructing a record decoder.

--- a/src/Json/Decode/Safe.elm
+++ b/src/Json/Decode/Safe.elm
@@ -138,14 +138,6 @@ field fieldName _ fieldValueDecoder (SafeDecoder builder) =
             |> endRecord
 
 -}
-endRecord :
-    SafeDecoder
-        { recordType : recordType
-        , expectedFieldOrder : expectedFieldOrder
-        , gotFieldOrder : expectedFieldOrder -> Bool
-        , totalFieldCount : totalFieldCount
-        }
-        recordType
-    -> JD.Decoder recordType
+endRecord : SafeDecoder safety recordType -> JD.Decoder recordType
 endRecord (SafeDecoder builder) =
     builder

--- a/src/Json/Decode/Safe.elm
+++ b/src/Json/Decode/Safe.elm
@@ -140,10 +140,9 @@ field fieldName _ fieldValueDecoder (SafeDecoder builder) =
 -}
 endRecord :
     SafeDecoder
-        { recordType : recordType
-        , expectedFieldOrder : expectedFieldOrder
-        , gotFieldOrder : expectedFieldOrder -> Bool
-        , totalFieldCount : totalFieldCount
+        { safety
+            | expectedFieldOrder : expectedFieldOrder
+            , gotFieldOrder : expectedFieldOrder -> Bool
         }
         recordType
     -> JD.Decoder recordType

--- a/src/Json/Decode/Safe.elm
+++ b/src/Json/Decode/Safe.elm
@@ -138,6 +138,14 @@ field fieldName _ fieldValueDecoder (SafeDecoder builder) =
             |> endRecord
 
 -}
-endRecord : SafeDecoder safety recordType -> JD.Decoder recordType
+endRecord :
+    SafeDecoder
+        { recordType : recordType
+        , expectedFieldOrder : expectedFieldOrder
+        , gotFieldOrder : expectedFieldOrder -> Bool
+        , totalFieldCount : totalFieldCount
+        }
+        recordType
+    -> JD.Decoder recordType
 endRecord (SafeDecoder builder) =
     builder

--- a/tests/SafeTest.elm
+++ b/tests/SafeTest.elm
@@ -1,0 +1,77 @@
+module SafeTest exposing (suite)
+
+import Expect exposing (Expectation)
+import Json.Decode as JD
+import Json.Decode.Safe as JDS
+import Test exposing (Test, describe, test)
+
+
+suite : Test
+suite =
+    describe "Json.Decode.Safe"
+        [ test "should decode valid JSON" <|
+            \() ->
+                """
+{
+  "firstName": "Ed",
+  "lastName": "Kelly",
+  "pets": 0
+}
+"""
+                    |> JD.decodeString userDecoder
+                    |> Expect.equal
+                        (Ok
+                            { firstName = "Ed"
+                            , lastName = "Kelly"
+                            , pets = 0
+                            }
+                        )
+        , test "should not decode invalid JSON" <|
+            \() ->
+                let
+                    invalidJson : String
+                    invalidJson =
+                        """
+{
+  "firstName": "Ed",
+  "pets": 0
+}
+"""
+                in
+                case JD.decodeString userDecoder invalidJson of
+                    Ok _ ->
+                        Expect.fail "Invalid JSON should not have been decoded successfully"
+
+                    Err error ->
+                        case error of
+                            JD.Failure message _ ->
+                                message
+                                    |> Expect.equal "Expecting an OBJECT with a field named `lastName`"
+
+                            _ ->
+                                Expect.fail ("Expected JSON decoding Failure but got " ++ Debug.toString error)
+        ]
+
+
+userDecoder : JD.Decoder User
+userDecoder =
+    JDS.record User userConstructor
+        |> JDS.field "firstName" .firstName JD.string
+        |> JDS.field "lastName" .lastName JD.string
+        |> JDS.field "pets" .pets JD.int
+        |> JDS.endRecord
+
+
+userConstructor : a -> b -> c -> { firstName : a, lastName : b, pets : c }
+userConstructor firstName lastName pets =
+    { firstName = firstName
+    , lastName = lastName
+    , pets = pets
+    }
+
+
+type alias User =
+    { firstName : String
+    , lastName : String
+    , pets : Int
+    }


### PR DESCRIPTION
It is possible to get the same type safety without the runtime code by using phantom types. This is a breaking change.

Feel free to rename `SafeDecoder` to something else, and to give it some documentation. I didn't get much inspiration so I left it empty for now.

I don't know if the last commit 602a4ad is necessarily an improvement, but I find it simpler. If you think that this is incorrect in the sense that it allows some unsafe operations, then we should probably cancel this change.

I also added a few tests: regular ones to check that JSON correctly decodes (but mostly that valid decoders should compile), and some tests that check that invalid decoders should not compile.